### PR TITLE
feat: Add history screen foundation

### DIFF
--- a/app/src/main/java/com/jesil/calculator/CalculatorScreen.kt
+++ b/app/src/main/java/com/jesil/calculator/CalculatorScreen.kt
@@ -14,9 +14,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -27,9 +32,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jesil.calculator.action.CalculatorAction
 import com.jesil.calculator.components.CalculatorDisplay
 import com.jesil.calculator.components.CalculatorKeypad
+import com.jesil.calculator.history.CalculatorHistoryScreen
 import com.jesil.calculator.ui.theme.CalculatorTheme
 import com.jesil.calculator.ui.theme.LargoTeal
 import com.jesil.calculator.ui.theme.OtherLargoTeal
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,6 +45,9 @@ fun CalculatorScreen() {
     val viewModel: CalculatorViewModel = viewModel()
     val expression by viewModel.expression.collectAsState()
     val answer by viewModel.answer.collectAsState()
+    val sheetState = rememberModalBottomSheetState()
+    var showBottomSheet by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -59,7 +69,9 @@ fun CalculatorScreen() {
                 },
                 actions = {
                     IconButton(
-                        onClick = {},
+                        onClick = {
+                            showBottomSheet = true
+                        },
                         content = {
                             Icon(
                                 tint = iconTint,
@@ -73,10 +85,23 @@ fun CalculatorScreen() {
         },
         content = { innerPadding ->
             CalculatorInnerScreen(
+                modifier = Modifier.padding(innerPadding),
                 expression = expression,
                 answer = answer,
                 onCalculatorButtonAction = viewModel::onCalculatorButtonAction
             )
+            if (showBottomSheet) {
+                CalculatorHistoryScreen(
+                    onDismiss = {
+                        coroutineScope.launch { sheetState.hide() }.invokeOnCompletion {
+                            if (!sheetState.isVisible) {
+                                showBottomSheet = false
+                            }
+                        }
+                    },
+                    sheetState = sheetState
+                )
+            }
         }
     )
 }
@@ -99,7 +124,7 @@ fun CalculatorInnerScreen(
                 expression = expression,
                 answer = answer,
                 modifier = Modifier
-                    .weight(.7f)
+                    .weight(.5f)
                     .padding(horizontal = 16.dp, vertical = 32.dp)
             )
             CalculatorKeypad(

--- a/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
+++ b/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
@@ -1,0 +1,122 @@
+package com.jesil.calculator.history
+
+import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
+import com.jesil.calculator.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CalculatorHistoryScreen(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    sheetState: SheetState
+) {
+    val history = remember { mutableListOf(emptyList<HistoryModel>()) }
+    var hasExpandedState = remember { false }
+
+    ModalBottomSheet(
+        modifier = modifier,
+        containerColor = MaterialTheme.colorScheme.background,
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            content = {
+                Button(
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(end = 20.dp),
+                    onClick = onDismiss,
+                    content = {
+                        Text(text = "Done")
+                    }
+                )
+                when(hasExpandedState) {
+                    true -> Box(
+                        modifier = Modifier
+                            .fillMaxSize(.5f)
+                            .background(MaterialTheme.colorScheme.background),
+                        contentAlignment = Alignment.Center,
+                        content = {
+                            NoHistoryDisplay()
+                        }
+                    )
+                    false -> NoHistoryDisplay(modifier.weight(1f))
+                }
+            }
+        )
+        LaunchedEffect(sheetState.targetValue.ordinal) {
+            when (sheetState.targetValue.ordinal) {
+                1 -> hasExpandedState = false
+                2 -> hasExpandedState = true
+            }
+            Log.e(
+                "CalculatorHistoryScreen",
+                "launched Effect: Launched!!"
+            )
+        }
+    }
+//    Log.e(
+//        "CalculatorHistoryScreen",
+//        "sheetState.hasPartiallyExpandedState: ${sheetState.hasPartiallyExpandedState}"
+//    )
+    Log.e(
+        "CalculatorHistoryScreen",
+        "sheetState.The sheet is now expanded: $hasExpandedState"
+    )
+    Log.e(
+        "CalculatorHistoryScreen",
+        "sheetState targetValue : ${sheetState.targetValue.ordinal}"
+    )
+}
+
+@Composable
+fun NoHistoryDisplay(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        content = {
+            Icon(
+                modifier = Modifier.size(40.dp),
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_history),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onBackground
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "No History",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/jesil/calculator/history/HistoryModel.kt
+++ b/app/src/main/java/com/jesil/calculator/history/HistoryModel.kt
@@ -1,0 +1,6 @@
+package com.jesil.calculator.history
+
+data class HistoryModel(
+    val expression: String,
+    val answer: String
+)


### PR DESCRIPTION
This commit introduces the basic structure and UI for the calculation history feature.

- **`HistoryModel.kt`:**
    - Adds a new `HistoryModel` data class to represent a single history entry, containing an `expression` and its corresponding `answer`.

- **`CalculatorHistoryScreen.kt`:**
    - Creates a new `CalculatorHistoryScreen` composable using `ModalBottomSheet` to display the history.
    - Implements a `NoHistoryDisplay` for the empty state, showing an icon and text.
    - Includes logic to detect if the bottom sheet is partially or fully expanded.

- **`CalculatorScreen.kt`:**
    - Integrates the `CalculatorHistoryScreen` as a modal bottom sheet.
    - Adds a `history` icon to the `TopAppBar` which, when clicked, sets `showBottomSheet` to `true` to display the history sheet.
    - Adjusts the layout weight of the `CalculatorDisplay` to accommodate the new feature.