### PR TITLE
feat: Animate history sheet expansion

### DIFF
--- a/app/src/main/java/com/jesil/calculator/history/CalcHistoryItem.kt
+++ b/app/src/main/java/com/jesil/calculator/history/CalcHistoryItem.kt
@@ -1,0 +1,78 @@
+package com.jesil.calculator.history
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.jesil.calculator.ui.theme.CalculatorTheme
+
+@Composable
+fun CalcHistoryItem(
+    modifier: Modifier = Modifier,
+    expression: String,
+    answer: String,
+) {
+    Row(
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        content = {
+            BoxWithBorder(text = expression)
+            Spacer(Modifier.width(20.dp))
+            Text(
+                text = "=",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            )
+            Spacer(Modifier.width(20.dp))
+            BoxWithBorder(text = answer)
+        }
+    ) 
+}
+
+@Composable
+fun BoxWithBorder(
+    text: String
+) {
+    Box(
+        modifier = Modifier.border(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            shape = RoundedCornerShape(15.dp)
+        ),
+        contentAlignment = Alignment.Center,
+        content = {
+            Text(
+                modifier = Modifier.padding(horizontal = 15.dp, vertical = 7.dp),
+                text = text,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.primary,
+                    fontSize = 20.sp
+                )
+            )
+        }
+    )
+}
+
+
+@PreviewLightDark
+@Composable
+private fun CalcHistoryItemPreview() = CalculatorTheme {
+    CalcHistoryItem(
+        modifier = Modifier.fillMaxWidth(),
+        expression = "2+2",
+        answer = "4",
+    )
+}

--- a/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
+++ b/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
@@ -1,6 +1,11 @@
 package com.jesil.calculator.history
 
 import android.util.Log
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,10 +22,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,7 +45,16 @@ fun CalculatorHistoryScreen(
     sheetState: SheetState
 ) {
     val history = remember { mutableListOf(emptyList<HistoryModel>()) }
-    var hasExpandedState = remember { false }
+    var hasExpandedState by remember { mutableStateOf(false) }
+
+    val targetFraction by animateFloatAsState(
+        targetValue = if (hasExpandedState) 1f else 0.4f,
+        animationSpec = if (hasExpandedState) {
+            tween(durationMillis = 300, easing = FastOutSlowInEasing)
+        } else {
+            tween(durationMillis = 300, easing = LinearOutSlowInEasing)
+        }
+    )
 
     ModalBottomSheet(
         modifier = modifier,
@@ -58,49 +76,29 @@ fun CalculatorHistoryScreen(
                         Text(text = "Done")
                     }
                 )
-                when(hasExpandedState) {
-                    true -> Box(
-                        modifier = Modifier
-                            .fillMaxSize(.5f)
-                            .background(MaterialTheme.colorScheme.background),
-                        contentAlignment = Alignment.Center,
-                        content = {
-                            NoHistoryDisplay()
-                        }
-                    )
-                    false -> NoHistoryDisplay(modifier.weight(1f))
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize(targetFraction)
+                        .animateContentSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    NoHistoryDisplay()
                 }
             }
         )
-        LaunchedEffect(sheetState.targetValue.ordinal) {
-            when (sheetState.targetValue.ordinal) {
-                1 -> hasExpandedState = false
-                2 -> hasExpandedState = true
+        LaunchedEffect(sheetState.targetValue) {
+            hasExpandedState = when (sheetState.targetValue) {
+                SheetValue.Expanded -> true
+                SheetValue.PartiallyExpanded -> false
+                SheetValue.Hidden -> false
             }
-            Log.e(
-                "CalculatorHistoryScreen",
-                "launched Effect: Launched!!"
-            )
         }
     }
-//    Log.e(
-//        "CalculatorHistoryScreen",
-//        "sheetState.hasPartiallyExpandedState: ${sheetState.hasPartiallyExpandedState}"
-//    )
-    Log.e(
-        "CalculatorHistoryScreen",
-        "sheetState.The sheet is now expanded: $hasExpandedState"
-    )
-    Log.e(
-        "CalculatorHistoryScreen",
-        "sheetState targetValue : ${sheetState.targetValue.ordinal}"
-    )
 }
 
 @Composable
-fun NoHistoryDisplay(modifier: Modifier = Modifier) {
+fun NoHistoryDisplay() {
     Column(
-        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
         content = {
@@ -110,7 +108,7 @@ fun NoHistoryDisplay(modifier: Modifier = Modifier) {
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onBackground
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(10.dp))
             Text(
                 text = "No History",
                 style = MaterialTheme.typography.bodyMedium.copy(

--- a/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
+++ b/app/src/main/java/com/jesil/calculator/history/CalculatorHistoryScreen.kt
@@ -1,21 +1,22 @@
 package com.jesil.calculator.history
 
-import android.util.Log
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -44,7 +45,7 @@ fun CalculatorHistoryScreen(
     onDismiss: () -> Unit,
     sheetState: SheetState
 ) {
-    val history = remember { mutableListOf(emptyList<HistoryModel>()) }
+    val history = remember { mapOf<String, List<HistoryModel>>() }
     var hasExpandedState by remember { mutableStateOf(false) }
 
     val targetFraction by animateFloatAsState(
@@ -76,13 +77,43 @@ fun CalculatorHistoryScreen(
                         Text(text = "Done")
                     }
                 )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize(targetFraction)
-                        .animateContentSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    NoHistoryDisplay()
+                when (fakeCalculationHistory.isNotEmpty()) {
+                    true ->
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.spacedBy(15.dp),
+                        ) {
+                            fakeCalculationHistory.forEach { (date, calculationHistories) ->
+                                item {
+                                    Text(
+                                        modifier = Modifier.padding(horizontal = 20.dp),
+                                        text = date,
+                                        style = MaterialTheme.typography.bodyMedium.copy(
+                                            color = MaterialTheme.colorScheme.onBackground
+                                        )
+                                    )
+                                }
+                                items(
+                                    items = calculationHistories,
+                                    itemContent = { calculationHistory ->
+                                        CalcHistoryItem(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            expression = calculationHistory.expression,
+                                            answer = calculationHistory.answer
+                                        )
+                                    }
+                                )
+                            }
+                        }
+
+                    else -> Box(
+                        modifier = Modifier
+                            .fillMaxSize(targetFraction)
+                            .animateContentSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        NoHistoryDisplay()
+                    }
                 }
             }
         )
@@ -118,3 +149,38 @@ fun NoHistoryDisplay() {
         }
     )
 }
+
+private val fakeCalculationHistory = mapOf<String, List<HistoryModel>>(
+   "2025-10-06" to listOf(
+       HistoryModel(
+           expression = "2+2",
+           answer = "4",
+           timeStamp = "10:00"
+       ),
+       HistoryModel(
+           expression = "2+2",
+           answer = "4",
+           timeStamp = "Today"
+       ),
+       HistoryModel(
+           expression = "3/5",
+           answer = "0.39791",
+           timeStamp = "Today"
+       ),
+       HistoryModel(
+           expression = "2+2",
+           answer = "4",
+           timeStamp = "Today"
+       ),
+       HistoryModel(
+           expression = "3/5+98-27",
+           answer = "0.39791",
+           timeStamp = "Today"
+       ),
+       HistoryModel(
+           expression = "2+2",
+           answer = "4",
+           timeStamp = "Today"
+       ),
+   )
+)

--- a/app/src/main/java/com/jesil/calculator/history/HistoryModel.kt
+++ b/app/src/main/java/com/jesil/calculator/history/HistoryModel.kt
@@ -2,5 +2,6 @@ package com.jesil.calculator.history
 
 data class HistoryModel(
     val expression: String,
-    val answer: String
+    val answer: String,
+    val timeStamp: String
 )


### PR DESCRIPTION
This commit enhances the UI of the history bottom sheet by adding a smooth animation when it expands and collapses.

- **`CalculatorHistoryScreen.kt`:**
  - Implements `animateFloatAsState` to dynamically adjust the sheet's fractional height (`targetFraction`) between a partially expanded state (40%) and a fully expanded state (100%).
  - The animation uses `FastOutSlowInEasing` for expansion and `LinearOutSlowInEasing` for collapsing.
  - The `Box` containing the history content now uses `animateContentSize()` for a smoother transition.
  - Refactors the state logic within `LaunchedEffect` to react to `sheetState.targetValue` (`Expanded`, `PartiallyExpanded`) instead of its ordinal value, improving code clarity.
  - Cleans up `NoHistoryDisplay` by removing the `modifier` parameter as it is now controlled by its parent `Box`.
  - Removes extensive logging.